### PR TITLE
Propose adding the relative orbit to the group name

### DIFF
--- a/docs/USER-REQUIREMENTS.md
+++ b/docs/USER-REQUIREMENTS.md
@@ -51,7 +51,7 @@ User experience
 Structure:
 
 * root / SAFE
-  * swaths "IW1" "IW2" "S3" etc / duplicated in VH-VV annotation XML
+  * relative orbit / swaths "22/IW1" "22/IW2" "124/S3" etc / duplicated in VH-VV annotation XML
     * bursts / polarization "N433_W0120_VV" etc (include polarization?)
     * gcp "gcp"
     * calibration "calibration"
@@ -59,7 +59,9 @@ Structure:
     * antenna pattern "antenna"
     * zero-Doppler "doppler"
 
-examples: `group="IW2/orbit"`, `group="IW2/N433_W0120_VV`, `group="S3/gcp"` etc
+examples: `group="22/IW2/orbit"`, `group="22/IW2/N433_W0120_VV`, `group="124/S3/gcp"` etc
+
+Burst groups with the same name e.g. `group="22/IW2/N433_W0120_VV`, are interferometric.
 
 Dimensions, coordinates and variables
 


### PR DESCRIPTION
Group names do not uniquely identify a burst, it possible (even if unlikely) that two relative orbits will have identical group names for different bursts, e.g. `group="IW2/N433_W0120_VV"`. Adding the relative orbit to the group structure will make all group names longer and more complex, but unique: e.g. `group="22/IW2/N433_W0120_VV"` and `group="169/IW2/N433_W0120_VV"`.

This is a trade-off. I'm not sure what naming scheme is best.

We could even accept both (causing even more confusion).