### PR TITLE
Fix burst coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ Attributes:
 <xarray.Dataset>
 Dimensions:           (azimuth_time: 1501, slant_range_time: 21632)
 Coordinates:
-    pixel             (slant_range_time) float64 0.5 1.5 ... 2.163e+04 2.163e+04
-    line              (azimuth_time) float64 1.051e+04 1.051e+04 ... 1.201e+04
+    pixel             (slant_range_time) int64 0 1 2 3 ... 21629 21630 21631
+    line              (azimuth_time) int64 10507 10508 10509 ... 12006 12007
   * azimuth_time      (azimuth_time) datetime64[ns] 2021-04-01T05:26:43.51577...
   * slant_range_time  (slant_range_time) float64 0.005343 0.005343 ... 0.005679
 Data variables:

--- a/xarray_sentinel/sentinel1.py
+++ b/xarray_sentinel/sentinel1.py
@@ -248,6 +248,9 @@ def open_swath_dataset(
     for pol, data_path in measurement_paths.items():
         arr = rioxarray.open_rasterio(data_path, chunks=chunks)
         arr = arr.squeeze("band").drop_vars(["band", "spatial_ref"])
+        arr.coords.update(
+            {"x": np.arange(0, arr["x"].size), "y": np.arange(0, arr["y"].size)}
+        )
         arr = arr.rename({"y": "line", "x": "pixel"})
         data_vars[pol.upper()] = arr
 

--- a/xarray_sentinel/sentinel1.py
+++ b/xarray_sentinel/sentinel1.py
@@ -248,7 +248,7 @@ def open_swath_dataset(
     for pol, data_path in measurement_paths.items():
         arr = rioxarray.open_rasterio(data_path, chunks=chunks)
         arr = arr.squeeze("band").drop_vars(["band", "spatial_ref"])
-        arr.coords.update(
+        arr = arr.assign_coords(
             {
                 "x": np.arange(0, arr["x"].size, dtype=int),
                 "y": np.arange(0, arr["y"].size, dtype=int),
@@ -312,7 +312,7 @@ def open_burst_dataset(
             x=slice(burst_first_pixel, burst_last_pixel + 1),
             y=slice(burst_first_line, burst_last_line + 1),
         )
-        arr.coords.update(
+        arr = arr.assign_coords(
             {
                 "x": np.arange(burst_first_pixel, burst_last_pixel + 1, dtype=int),
                 "y": np.arange(burst_first_line, burst_last_line + 1, dtype=int),

--- a/xarray_sentinel/sentinel1.py
+++ b/xarray_sentinel/sentinel1.py
@@ -306,6 +306,12 @@ def open_burst_dataset(
             x=slice(burst_first_pixel, burst_last_pixel + 1),
             y=slice(burst_first_line, burst_last_line + 1),
         )
+        arr.coords.update(
+            {
+                "x": np.arange(burst_first_pixel, burst_last_pixel + 1),
+                "y": np.arange(burst_first_line, burst_last_line + 1),
+            }
+        )
         arr = arr.rename({"y": "line", "x": "pixel"})
         data_vars[pol.upper()] = arr
 


### PR DESCRIPTION
Use integers values (in swath and bursts) for pixel and line coordinates instead of integers plus 0.5. NOw there are aligned with calibration paramteres coordinates.
Previus swath dataset:
```python
Dimensions:  (line: 13509, pixel: 21632)
Coordinates:
  * line     (line) float64 0.5 1.5 2.5 3.5 ... 1.351e+04 1.351e+04 1.351e+04
  * pixel    (pixel) float64 0.5 1.5 2.5 3.5 ... 2.163e+04 2.163e+04 2.163e+04
 ...
 ```
Current swath dataset:
```python
Dimensions:  (line: 13509, pixel: 21632)
Coordinates:
  * line     (line) int64 0 1 2 3 4 5 6 ... 13503 13504 13505 13506 13507 13508
  * pixel    (pixel) int64 0 1 2 3 4 5 6 ... 21626 21627 21628 21629 21630 21631
 ...
```