### PR TITLE
fix: Support Sentinel-1C

### DIFF
--- a/xarray_sentinel/esa_safe.py
+++ b/xarray_sentinel/esa_safe.py
@@ -97,7 +97,7 @@ def findall(
 
 def parse_annotation_filename(name: str) -> tuple[str, str, str, str]:
     match = re.match(
-        r"([a-z-]*)s1[ab]-([^-]*)-[^-]*-([^-]*)-([\dt]*)-", os.path.basename(name)
+        r"([a-z-]*)s1[abc]-([^-]*)-[^-]*-([^-]*)-([\dt]*)-", os.path.basename(name)
     )
     if match is None:
         raise ValueError(f"cannot parse name {name!r}")


### PR DESCRIPTION
Modified ESA regex to support Sentinel-1C products. This should fix https://github.com/bopen/xarray-sentinel/issues/154.

Credit to @priit111 for the fix