### PR TITLE
Fix compatibility with xarray >= 2026.02

### DIFF
--- a/tests/test_30_xarray_backends.py
+++ b/tests/test_30_xarray_backends.py
@@ -76,7 +76,7 @@ def test_open_dataset_root() -> None:
 
     assert isinstance(res, xr.Dataset)
 
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, FileNotFoundError)):
         xr.open_dataset("")
 
 


### PR DESCRIPTION
The return exception for a missing dataset is now `FileNotFoundError`, no longer `ValueError`:

https://github.com/pydata/xarray/commit/160a85c04f58dafabd63169a9c2c401a5888b39a

Original patch provided in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1138617